### PR TITLE
Issue#33 v0.0.1

### DIFF
--- a/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/dtos/EventDTO.java
+++ b/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/dtos/EventDTO.java
@@ -1,7 +1,7 @@
 package br.edu.ifrn.laj.pdcorp.apisea.dtos;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 
 import javax.validation.constraints.NotBlank;
@@ -22,17 +22,17 @@ public class EventDTO {
 	private String thumbPath;
 
 	@NotNull
-	private Calendar subscriptionStart;
+	private LocalDateTime subscriptionStart;
 
 	@NotNull
-	private Calendar subscriptionEnd;
+	private LocalDateTime subscriptionEnd;
 
 	public EventDTO() {
 		super();
 	}
 
 	public EventDTO(@NotNull Long id, @NotBlank String name, @NotBlank String summary, String thumbPath,
-			@NotNull Calendar subscriptionStart, @NotNull Calendar subscriptionEnd) {
+			@NotNull LocalDateTime subscriptionStart, @NotNull LocalDateTime subscriptionEnd) {
 		this();
 		this.id = id;
 		this.name = name;
@@ -98,19 +98,19 @@ public class EventDTO {
 		this.thumbPath = thumbPath;
 	}
 
-	public Calendar getSubscriptionStart() {
+	public LocalDateTime getSubscriptionStart() {
 		return subscriptionStart;
 	}
 
-	public void setSubscriptionStart(Calendar subscriptionStart) {
+	public void setSubscriptionStart(LocalDateTime subscriptionStart) {
 		this.subscriptionStart = subscriptionStart;
 	}
 
-	public Calendar getSubscriptionEnd() {
+	public LocalDateTime getSubscriptionEnd() {
 		return subscriptionEnd;
 	}
 
-	public void setSubscriptionEnd(Calendar subscriptionEnd) {
+	public void setSubscriptionEnd(LocalDateTime subscriptionEnd) {
 		this.subscriptionEnd = subscriptionEnd;
 	}
 

--- a/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/dtos/SubscriptionDTO.java
+++ b/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/dtos/SubscriptionDTO.java
@@ -1,7 +1,7 @@
 package br.edu.ifrn.laj.pdcorp.apisea.dtos;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 
 import br.edu.ifrn.laj.pdcorp.apisea.models.Subscription;
@@ -9,7 +9,7 @@ import br.edu.ifrn.laj.pdcorp.apisea.models.Subscription;
 public class SubscriptionDTO {
 
 	private Long id;
-	private Calendar lastChangeDate;
+	private LocalDateTime lastChangeDate;
 
 	private UserDTO user;
 
@@ -19,7 +19,7 @@ public class SubscriptionDTO {
 		super();
 	}
 
-	public SubscriptionDTO(Long id, Calendar lastChangeDate, UserDTO user, EventDTO event) {
+	public SubscriptionDTO(Long id, LocalDateTime lastChangeDate, UserDTO user, EventDTO event) {
 		this();
 		this.id = id;
 		this.lastChangeDate = lastChangeDate;
@@ -55,11 +55,11 @@ public class SubscriptionDTO {
 		this.id = id;
 	}
 
-	public Calendar getLastChangeDate() {
+	public LocalDateTime getLastChangeDate() {
 		return lastChangeDate;
 	}
 
-	public void setLastChangeDate(Calendar lastChangeDate) {
+	public void setLastChangeDate(LocalDateTime lastChangeDate) {
 		this.lastChangeDate = lastChangeDate;
 	}
 

--- a/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/enums/ExceptionMessages.java
+++ b/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/enums/ExceptionMessages.java
@@ -10,7 +10,8 @@ public enum ExceptionMessages {
 	EVENT_DOESNT_EXISTS_DB("Evento não encontrado."),
 	SUBSCRIPTION_DOESNT_EXISTS_DB("Inscrição não encontrada."), 
 	SUBSCRIPTION_ALREADY_EXISTS("Inscrição já existe."), 
-	INVALID_DATETIME_FOR_SUBSCRIPTION("A data atual não está dentro do período de inscrição");
+	INVALID_DATETIME_FOR_SUBSCRIPTION("A data atual não está dentro do período de inscrição"), 
+	EVENT_IS_NOT_ACTIVE_FOR_SUBSCRIPTION("Não é possível se inscrever em eventos inativos.");
 	
 	private String description;
 	

--- a/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/enums/ExceptionMessages.java
+++ b/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/enums/ExceptionMessages.java
@@ -9,7 +9,8 @@ public enum ExceptionMessages {
 	USER_REQUEST_FORBBIDEN("A requisição não permitida para este usuário."),
 	EVENT_DOESNT_EXISTS_DB("Evento não encontrado."),
 	SUBSCRIPTION_DOESNT_EXISTS_DB("Inscrição não encontrada."), 
-	SUBSCRIPTION_ALREADY_EXISTS("Inscrição já existe.");
+	SUBSCRIPTION_ALREADY_EXISTS("Inscrição já existe."), 
+	INVALID_DATETIME_FOR_SUBSCRIPTION("A data atual não está dentro do período de inscrição");
 	
 	private String description;
 	

--- a/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/models/Event.java
+++ b/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/models/Event.java
@@ -1,6 +1,6 @@
 package br.edu.ifrn.laj.pdcorp.apisea.models;
 
-import java.util.Calendar;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -28,10 +28,10 @@ public class Event {
 	private String thumbPath;
 
 	@NotNull
-	private Calendar subscriptionStart;
+	private LocalDateTime subscriptionStart;
 
 	@NotNull
-	private Calendar subscriptionEnd;
+	private LocalDateTime subscriptionEnd;
 
 	@ManyToOne
 	@NotNull
@@ -44,7 +44,7 @@ public class Event {
 	}
 
 	public Event(Long id, @NotBlank String name, @NotBlank String summary, String thumbPath,
-			@NotNull Calendar subscriptionStart, @NotNull Calendar subscriptionEnd) {
+			@NotNull LocalDateTime subscriptionStart, @NotNull LocalDateTime subscriptionEnd) {
 		this();
 		this.id = id;
 		this.name = name;
@@ -55,7 +55,7 @@ public class Event {
 	}
 
 	public Event(Long id, @NotBlank String name, @NotBlank String summary, String thumbPath,
-			@NotNull Calendar subscriptionStart, @NotNull Calendar subscriptionEnd, @NotNull User owner) {
+			@NotNull LocalDateTime subscriptionStart, @NotNull LocalDateTime subscriptionEnd, @NotNull User owner) {
 		this(id, name, summary, thumbPath, subscriptionStart, subscriptionEnd);
 		this.owner = owner;
 	}
@@ -92,19 +92,19 @@ public class Event {
 		this.thumbPath = thumbPath;
 	}
 
-	public Calendar getSubscriptionStart() {
+	public LocalDateTime getSubscriptionStart() {
 		return subscriptionStart;
 	}
 
-	public void setSubscriptionStart(Calendar subscriptionStart) {
+	public void setSubscriptionStart(LocalDateTime subscriptionStart) {
 		this.subscriptionStart = subscriptionStart;
 	}
 
-	public Calendar getSubscriptionEnd() {
+	public LocalDateTime getSubscriptionEnd() {
 		return subscriptionEnd;
 	}
 
-	public void setSubscriptionEnd(Calendar subscriptionEnd) {
+	public void setSubscriptionEnd(LocalDateTime subscriptionEnd) {
 		this.subscriptionEnd = subscriptionEnd;
 	}
 

--- a/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/models/Subscription.java
+++ b/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/models/Subscription.java
@@ -1,6 +1,6 @@
 package br.edu.ifrn.laj.pdcorp.apisea.models;
 
-import java.util.Calendar;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -16,7 +16,7 @@ public class Subscription {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private Calendar lastChangeDate;
+	private LocalDateTime lastChangeDate;
 
 	@ManyToOne
 	@NotNull
@@ -34,11 +34,11 @@ public class Subscription {
 		this.id = id;
 	}
 
-	public Calendar getLastChangeDate() {
+	public LocalDateTime getLastChangeDate() {
 		return lastChangeDate;
 	}
 
-	public void setLastChangeDate(Calendar lastChangeDate) {
+	public void setLastChangeDate(LocalDateTime lastChangeDate) {
 		this.lastChangeDate = lastChangeDate;
 	}
 

--- a/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/services/SubscriptionService.java
+++ b/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/services/SubscriptionService.java
@@ -1,6 +1,7 @@
 package br.edu.ifrn.laj.pdcorp.apisea.services;
 
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
@@ -65,7 +66,7 @@ public class SubscriptionService {
 		if (subscriptionRepository.findByUserAndEvent(user, event) != null)
 			throw new ApiSubscriptionException(ExceptionMessages.SUBSCRIPTION_ALREADY_EXISTS);
 
-		subscription.setLastChangeDate(Calendar.getInstance());
+		subscription.setLastChangeDate(LocalDateTime.now());
 
 		return SubscriptionDTO.convertFromModel(subscriptionRepository.save(subscription));
 	}
@@ -79,7 +80,7 @@ public class SubscriptionService {
 			throw new ApiSubscriptionException(ExceptionMessages.USER_REQUEST_FORBBIDEN);
 
 		BeanUtils.copyProperties(subscription, existent, "id", "user", "event");
-		existent.setLastChangeDate(Calendar.getInstance());
+		existent.setLastChangeDate(LocalDateTime.now());
 
 		return SubscriptionDTO.convertFromModel(subscriptionRepository.save(existent));
 	}

--- a/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/services/SubscriptionService.java
+++ b/backend/api-sea/src/main/java/br/edu/ifrn/laj/pdcorp/apisea/services/SubscriptionService.java
@@ -60,6 +60,9 @@ public class SubscriptionService {
 		User user = this.findUserAuthenticated(principal);
 		Event event = this.findEventById(subscription.getEvent().getId());
 
+		if(!event.isActive())
+			throw new ApiSubscriptionException(ExceptionMessages.EVENT_IS_NOT_ACTIVE_FOR_SUBSCRIPTION);
+		
 		LocalDateTime actualLocalDateTime = LocalDateTime.now();
 
 		if (!this.isLocalDateTimeValidForSubscriptionInEvent(actualLocalDateTime, event))
@@ -80,6 +83,9 @@ public class SubscriptionService {
 			throws ApiSubscriptionException {
 		Subscription existent = this.findSubscriptionById(id);
 		User user = this.findUserAuthenticated(principal);
+		
+		if(!existent.getEvent().isActive())
+			throw new ApiSubscriptionException(ExceptionMessages.EVENT_IS_NOT_ACTIVE_FOR_SUBSCRIPTION);
 		
 		LocalDateTime actualLocalDateTime = LocalDateTime.now();
 


### PR DESCRIPTION
Nesse PR foram implementados os seguintes requisitos:
- As datas das classes Event e Subscription foram alteradas para o tipo LocalDateTime, que armazena a data e a hora sem o fuso horário. Achei essa mais adequada.
- A inscrição em um determinado evento agora passa pela validação da data. A data que a inscrição é realizada tem que estar dentro do intervalo de inscrição definido para o evento. Essa validação também é realizada no caso de alteração da inscrição.
- Validação para que inscrições não possam ser realizadas (ou alteradas) em eventos que estejam inativos.

Uma vez que a nova api de datas do Java 8 não possui um método para verificar se a data é "igual ou está depois" de outra data, implementei um método privado na classe SubscriptionService que recebe um LocalDateTime e um Event e verifica se esse LocalDateTime está dentro do intervalo de inscrição do evento.

closes #33 